### PR TITLE
Fix mailto href in Section508 mailbox link

### DIFF
--- a/_events/2021-11-17-dec-itacm.md
+++ b/_events/2021-11-17-dec-itacm.md
@@ -25,7 +25,7 @@ The next IT Accessibility Community Meeting (ITACM) will be on Tuesday, December
 **[Registration](https://feedback.gsa.gov/jfe/form/SV_5hhVlJZeuzpJ4nI)** is now open and will close December 3rd at 12:00 PM (EST)
 
 ## OPTIONAL UGLY SWEATER CONTEST DURING THE EVENT
-Keeping with our December meeting tradition, the annual **"Beauty Is In The Eye Of The Beholder" Ugly Sweater Contest** will take place. Take a picture of yourself in your "best" holiday sweater and submit it to [section.508@gsa.gov](section.508@gsa.gov) by 3:00 PM (EST) on Friday, December 3rd. Please include your name and agency with your picture.* You must be present at the meeting wearing your sweater to be eligible to win. Voting for the best ugly sweater will take place during the meeting. Our reigning champ from last year’s ugly sweater contest is Tim Creagan, from the Access Board. Will he be dethroned this year?
+Keeping with our December meeting tradition, the annual **"Beauty Is In The Eye Of The Beholder" Ugly Sweater Contest** will take place. Take a picture of yourself in your "best" holiday sweater and submit it to [section.508@gsa.gov](mailto:section.508@gsa.gov) by 3:00 PM (EST) on Friday, December 3rd. Please include your name and agency with your picture.* You must be present at the meeting wearing your sweater to be eligible to win. Voting for the best ugly sweater will take place during the meeting. Our reigning champ from last year’s ugly sweater contest is Tim Creagan, from the Access Board. Will he be dethroned this year?
 
 ***Note:** By submitting your picture, you agree to the following:
 


### PR DESCRIPTION
Just noticed the mailbox link is leading to our 404 page. Quick fix.