### PR TITLE
provide redirect from old link in course

### DIFF
--- a/_pages/training/2018-05-08-tools-coordinator-listing.md
+++ b/_pages/training/2018-05-08-tools-coordinator-listing.md
@@ -5,6 +5,8 @@ permalink: tools/coordinator-listing/
 type: training
 title: 'Find Your 508 Program Manager'
 created: 1525805876
+redirect_from:
+- 508-coordinator-listing/
 ---
 
 Agency Section 508 Program Managers (PMs) are your first point of contact for questions about IT accessibility. Find your agency’s designated Section 508 PM below.


### PR DESCRIPTION
USDA noted that links in the "Section 508: What is it and Why is it Important?" course resulted in 504 message for [section508.gov/508-coordinator-listing](https://www.section508.gov/508-coordinator-listing/). Adding redirect on [tools/coordinator-listing](https://www.section508.gov/tools/coordinator-listing/).