### PR TITLE
Add redirects for links listed in training course

### DIFF
--- a/_pages/manage/2018-05-29-manage-laws-and-policies.md
+++ b/_pages/manage/2018-05-29-manage-laws-and-policies.md
@@ -5,6 +5,8 @@ permalink: manage/laws-and-policies/
 type: manage
 title: 'IT Accessibility Laws and Policies'
 created: 1527612022
+redirect_from:
+- summary-section508-standards/
 ---
 
 [Section 508 Policy][1]  

--- a/_pages/training/playbooks/2018-05-15-tools-playbooks-technology-accessibility-playbook-intro.md
+++ b/_pages/training/playbooks/2018-05-15-tools-playbooks-technology-accessibility-playbook-intro.md
@@ -4,6 +4,8 @@ type: training
 layout: page
 title: 'Technology Accessibility Playbook'
 created: 1526408212
+redirect_from:
+- content/technology-accessibility-playbook/
 ---
 
 <div>


### PR DESCRIPTION
From "Section 508: What is it and Why is it Important" course > [resources page](https://training.section508.gov/508-training/courses/508-basics/a001_resources_resources.html)
  * Add redirect from summary-section508-standards to manage/laws-and-policies/
  * Add redirect from content/technology-accessibility-playbook to tools/playbooks/technology-accessibility-playbook-intro/