### PR TITLE
Updated web links and references to Federal Relay

### DIFF
--- a/_pages/content-pages/2020-02-27-content-glossary.md
+++ b/_pages/content-pages/2020-02-27-content-glossary.md
@@ -92,6 +92,9 @@ created: 1582828796
       <strong><span id="caret">Caret</span>:</strong> An on-screen indication of the text input focus in a text edit field.
     </li>
     <li>
+      <strong><span id="cart">Communication Access Realtime Translation (CART)</span>:</strong> Live instant translation of the spoken word into text using a stenotype machine, notebook computer and realtime software. For CART services, search your agency intranet, or contact your agency <a href="http://www.gsa.gov/fedrelay">relay official</a>.
+    </li>
+    <li>
       <strong><span id= "css">Cascading Style Sheets (CSS)</span>:</strong>&nbsp;CSS is a computer language used to style the presentation of a document written in a markup language,&nbsp;such as&nbsp;<a href="#html" target="_blank">HTML</a>. Along with HTML and&nbsp;<a href="#javascript" target="_blank">JavaScript</a>, CSS is a key technology of the World Wide Web. CSS enables presentation and content to be programmatically separated, including layout, colors, and fonts, which can improve content accessibility, and makes it possible to present the same page in different styles for different rendering methods such as desktops, mobile devices, for printing, and when using&nbsp;<a href="#assistive-technology" target="_blank">assistive technologies</a>&nbsp;such as text-to-speech and Braille-based tactile devices. The&nbsp;<a href="https://www.w3.org/Style/CSS/" target="_blank">CSS specifications</a>&nbsp;are maintained by the&nbsp;<a href="https://www.w3.org/" target="_blank">World Wide Web Consortium</a>&nbsp;(W3C).&nbsp;
     </li>
     <li>
@@ -161,7 +164,7 @@ created: 1582828796
       <strong><span id="far">Federal Acquisition Regulation (FAR)</span>:</strong> Principal set of rules in the Federal Acquisition Regulations System regarding&nbsp; United States government procurement.
     </li>
     <li>
-      <strong><span id="fedrelay">FedRelay</span>:</strong>&nbsp;<a href="https://www.federalrelay.us" target="_blank">FedRelay</a> provides telecommunications services for federal agencies and tribal governments to conduct official business with individuals who are deaf or hard of hearing, or have speech disabilities.
+      <strong><span id="fedrelay">FedRelay</span>:</strong> Federal Relay services expired February 13, 2022. FedRelay was a provides telecommunications services for federal agencies and tribal governments to conduct official business with individuals who are deaf or hard of hearing, or have speech disabilities. Agencies can access <a href="http://www.gsa.gov/fedrelay" target="_blank">relay services</a> through through Federal Communications Commission (FCC) Telecommunications Relay Service (TRS) and General Services Administration (GSA) Multiple Award Schedule Translation and Interpretation Services.
     </li>
     <li>
       <strong><span id="focus">Focus</span>:</strong> In a graphical user interface, a window (e.g., a button) or a location within a window (e.g., position of a text cursor or mouse pointer), to which the operating system will direct user input. Users can set the focus by using the keyboard, the mouse, or other input devices.
@@ -439,10 +442,12 @@ created: 1582828796
       <strong><span id="table">Table</span>:</strong> A two-dimensional group of rectangular cells organized into rows and columns. Tables can be used to display information, or used as a method of laying out information.
     </li>
     <li>
-      <strong><span id="table-header">Table header</span>:</strong> The name of a category of data in a<a href="#data-table"> data table</a> row or column. In a<a href="#simple-data-table"> simple data table</a>, column headers are provided in the first row and apply to the data cells in their respective columns. Similarly, row headers are provided in the first column and apply to the data cells in their respective rows. In a<a href="#complex-data-table"> complex data table</a>, a column header may be defined in any row, and may apply to multiple columns or to a few cells in a column, and a row header may be defined in any column, and may apply to multiple rows or to a few cells in a row.
+      <strong><span id="table-header">Table header</span>:</strong> The name of a category of data in a <a href="#data-table">data table</a> row or column. In a<a href="#simple-data-table"> simple data table</a>, column headers are provided in the first row and apply to the data cells in their respective columns. Similarly, row headers are provided in the first column and apply to the data cells in their respective rows. In a<a href="#complex-data-table"> complex data table</a>, a column header may be defined in any row, and may apply to multiple columns or to a few cells in a column, and a row header may be defined in any column, and may apply to multiple rows or to a few cells in a row.
+    </li>
+    <li><strong><span id="trs">Telecommunications Relay Services (TRS)</span>:</strong> <a href="https://www.fcc.gov/trs">Telecommunications Relay Services (TRS)</a> allow persons who are deaf, hard of hearing, deafblind, or have speech disabilities to communicate by telephone in a manner that is functionally equivalent to telephone services used by persons without such disabilities. 
     </li>
     <li>
-      <strong><span id="telecommunications"> Telecommunications</span>:</strong>The signal transmission of information of the user’s choosing, between or among points specified by the user, without change in the form or content of the information as sent and received.
+      <strong><span id="telecommunications">Telecommunications</span>:</strong> The signal transmission of information of the user’s choosing, between or among points specified by the user, without change in the form or content of the information as sent and received.
     </li>
     <li>
       <strong><span id="terminal">Terminal</span>:</strong> Device or software that provides the user interface through which the end user directly interacts. For some systems, the software that provides the user interface may reside on more than one device such as a telephone and a server.

--- a/_pages/create/create-accessible-meetings.md
+++ b/_pages/create/create-accessible-meetings.md
@@ -90,7 +90,7 @@ Confirm that the availability and accessibility of features is available for the
 <li>
 <strong>Captioning:</strong> For attendees who are deaf or hard-of-hearing, conference materials that include an audio component should have a text version accompanying it (e.g., open or closed captioning). This includes all training and informational video and multimedia productions which support the agency’s mission (both live and pre-recorded).
 <ul>
-<li><i>Real-Time (Live):</i> Provide real-time, two-way captioning (e.g., <a href="https://www.federalrelay.us" class="ext">Federal Relay<span class="ext" aria-label="(link is external)"></span></a>) to enable participants to interact and participate in the meeting via a professional captioner. </li>
+<li><i>Real-Time (Live):</i> Provide real-time, two-way captioning (e.g., <a href="https://www.federalrelay.us" target="_blank">Communication Access Realtime Translation (CART) available through your agency</a>) to enable participants to interact and participate in the meeting via a professional captioner. </li>
 <li><i>Automated:</i> Virtual platforms have increasingly integrated automated speech to text translation into their products. While these solutions may be serviceable for some, others may lack a human captioner’s ability to translate heavily accented speech, acronyms and jargon, as well as provide an indication of speaker change, grammar and punctuation. Be prepared to provide professional real-time, human-generated captions. </li>
 </ul>
 </li>
@@ -138,7 +138,7 @@ Confirm that the availability and accessibility of features is available for the
 <li dir="ltr"><strong>Speakers:</strong> List of attendees and presenters; include speaker biographies for larger meetings, webinars and conferences</li>
 <li dir="ltr"><strong>Schedule of events:</strong> Specific dates and times of how the meeting has been organized; including speakers, breaks, etc.</li>
 <li dir="ltr"><strong>How to Join:</strong> Provide detailed information on the ways attendees can participate in the meeting (e.g., links to virtual platform, alternate telephone number)</li>
-<li dir="ltr"><strong>Accommodations:</strong> Include detailed information on how individuals can access available accommodations, (e.g., FedRelay Relay Conference Captioning (RCC), ASL interpreters, assisted listening devices, alternate print formats)</li>
+<li dir="ltr"><strong>Accommodations:</strong> Include detailed information on how individuals can access available accommodations, (e.g., Communication Access Realtime Translation (CART), ASL interpreters, assisted listening devices, alternate print formats)</li>
 <li dir="ltr"><strong>Materials:</strong> Whenever possible, distribute electronic presentation documents and media to invitees and attendees in advance of the meeting</li>
 <li dir="ltr"><strong>Tech Checks:</strong> Provide ways for participants to test platform access prior to meeting (e.g., <a href="https://zoom.us/test" class="ext">zoom test meeting<span class="ext" aria-label="(link is external)"></span></a>), particularly when inviting individuals from outside of your organization</li>
 </ul>
@@ -296,7 +296,7 @@ Fine tune your video
 <ul>
 <li dir="ltr"><a href="{{site.baseurl}}/create">Create Accessible Digital Products</a></li>
 <li dir="ltr"><a href="{{site.baseurl}}/create/universal-design">Universal Design and Accessibility</a></li>
-<li dir="ltr"><a href="https://www.federalrelay.us/" class="ext">FedRelay<span class="ext" aria-label="(link is external)"></span></a></li>
+<li dir="ltr"><a href="https://www.gsa.gov/fedrelay/" class="ext">FedRelay<span class="ext" aria-label="(link is external)"></span></a></li>
 <li dir="ltr"><a href="https://www.w3.org/WAI/people-use-web/" class="ext">How People with Disabilities Used the Web<span class="ext" aria-label="(link is external)"></span></a> (W3C WCAG)</li>
 <li dir="ltr"><a href="https://www.cdc.gov/ncbddd/hearingloss/transcripts/Making-Meetings-Accessible.pdf">Making Meetings Accessible</a> (CDC.gov)</li>
 <li dir="ltr"><a href="https://www1.nyc.gov/assets/mopd/downloads/pdf/virtual-meetings-accessibility-guide_05-01-2020.pdf">NYC Accessible Virtual Meetings Guide</a> (NYC.gov)</li>

--- a/_posts/2020-04-02-blog-making-agency-communications-accessible-everyone.md
+++ b/_posts/2020-04-02-blog-making-agency-communications-accessible-everyone.md
@@ -45,18 +45,17 @@ The following tips will help you to create accessible digital content.
 
 ## Videos and Virtual Meetings
 
-  * Captions are required for information provided by speech or sound. Consider using [FedRelay][5] solutions, such as [Relay Conference Captioning][6] (RCC), to caption your conference call or webinar.&nbsp;
-
+  * Captions are required for information provided by speech or sound. Consider live translation solutions such as Communication Access Realtime Translation (CART) to caption your conference call or webinar. 
   * Include descriptions of visual content in speaker narration. Otherwise, provide audio descriptions for information provided through graphics and pictures.
   * Make sure the media player controls are keyboard accessible.
-  * Review this [Video, Audio and Social][7] guidance for more information.
+  * Review this [Video, Audio and Social][6] guidance for more information.
 
 ## Social Media
 
   * Verify that your chosen platforms allow for the addition of captions on images or videos.
       * For images without ALT text, caption the images in the text of the post.
       * For inaccessible videos, include a link to an accessible version of the video on your agency website.
-  * Review this [Video, Audio and Social][7] guidance for more information.
+  * Review this [Video, Audio and Social][6] guidance for more information.
 
 Please contact us at <Section.508@gsa.gov> if you have questions or need additional assistance.
 
@@ -67,5 +66,4 @@ This guidance was developed by the Federal CIO Council&rsquo;s Interagency Acces
  [3]: {{site.baseurl}}/content/guide-accessible-web-design-development
  [4]: https://designsystem.digital.gov/
  [5]: https://www.federalrelay.us/
- [6]: https://www.federalrelay.us/rcc
- [7]: {{site.baseurl}}/create/video-social
+ [6]: {{site.baseurl}}/create/video-social/


### PR DESCRIPTION
Updated web links and references to Federal Relay which expired on Feb 13, 2022. Links updated to gsa.gov/fedrelay to provide users with transition and point of contact information. 