### PR TITLE
substitue img src in search submit button

### DIFF
--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -16,7 +16,7 @@
     <div role="search">
       <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
       <input class="usa-input usagov-search-autocomplete" id="extended-search-field-small" type="search" name="query" autocomplete="off">
-      <button class="usa-button primary-background-color" type="submit"><span class="usa-sr-only">Search</span></button>
+      <button class="usa-button primary-background-color" type="submit"><img src="/img/usa-icons-bg/search--white.svg" class="usa-search__submit-icon" alt="Search"></button>
     </div>
   </form>
 {% endif %}


### PR DESCRIPTION
Fixing the missing magnifying glass icon in the submit search button