### PR TITLE
Homepage Quick Links

### DIFF
--- a/_includes/tagline.html
+++ b/_includes/tagline.html
@@ -7,19 +7,19 @@ This tagline will appear in your homepage
       <h2 class="font-body-lg margin-bottom-5 margin-top-0 text-black">Quick Links</h2>
       <div class="grid-row grid-gap">
           <div class="desktop:grid-col-3 text-center">
-            <a href="{{site.baseurl}}/create" class="text-no-underline display-inline-block">
+            <a href="{{site.baseurl}}/training-home/#micro-purchase" class="text-no-underline display-inline-block">
               <div class="circle icons">
-                {% asset icons/pen.svg class="icon" alt="Content Index" aria-hidden="true" %}
+                <img src="https://assets.section508.gov/files/images/icons/training-qlinks.png" class="icon-1" alt="Micro-Purchases and Section 508 Requirements" aria-hidden="true">
               </div>
-              <p class="text-black font-body-md text-no-underline text-bold">Content Index</p>
+              <p class="text-black font-body-md text-no-underline text-bold">Micro-Purchases <br>and Section 508 Requirements</p>
             </a>
           </div>
           <div class="desktop:grid-col-3 text-center">
-            <a href="{{site.baseurl}}/blog" class="text-no-underline display-inline-block">
+            <a href="{{site.baseurl}}/manage/laws-and-policies/" class="text-no-underline display-inline-block">
               <div class="circle icons">
-                {% asset icons/XMLID_1203_.svg class="icon" alt="Blogs & Updates" aria-hidden="true" %}
+                <img src="https://assets.section508.gov/files/images/icons/law-policy-qlinks.png" class="icon-1" alt="IT Accessibiility Laws and Policies" aria-hidden="true">
               </div>
-              <p class="text-black font-body-md text-no-underline text-bold">Blogs & Updates</p>
+              <p class="text-black font-body-md text-no-underline text-bold">IT Accessibiility Laws and Policies</p>
             </a>
           </div>
           <div class="desktop:grid-col-3 text-center">

--- a/_pages/training/2018-05-08-training.md
+++ b/_pages/training/2018-05-08-training.md
@@ -31,26 +31,27 @@ The courses listed below are intended to improve&nbsp;your understanding of IT a
 
 The following self-paced courses provide an overview of key aspects of IT accessibility. (_Note: Some of these courses are also available through the_ [_Federal Acquisition Institute (FAI)_][2]_. If you need to earn Continuous Learning Points (CLPs) to meet annual training requirements, we recommend you take designated courses through FAI.)_
 
+<span id="508-awareness"></span>
   * **<a href="https://training.section508.gov/508-training/courses/new/index.html" target="_blank">Section 508 Awareness</a>** &ndash; What is a Section 508 Program? This course provides an overview of federal agency 508 programs, and how they help agencies deliver accessible technology products and services to employees and the public.  
     **Audience**: Acquisition and procurement professionals; anyone writing a Statement of Objectives (SOO) that incorporates technology; CIOs, CAOs, or anyone interested in learning more about Section 508  
     **Course length**: 30 minutes  
     **Certificate or CLPs available?**: Yes
 
-
-
+<span id="it-accessability"></span>
   * **<a href="https://training.section508.gov/508-training/courses/exec-overview/index.html" target="_blank"><strong>Accessibility of ICT: An Overview for Government Executives</strong></a>** &ndash; High-level overview of the Revised 508 Standards. Explains roles and responsibilities of Federal government executives, including agency heads, CIOs and CAOs, and Section 508 Program Managers.  
     **Audience**: Agency Executives  
     **Course length**: 15 minutes  
     **Certificate or CLPs available?**: No
 
-
-  
+<span id="508-basics"></span>  
   * **<a href="https://training.section508.gov/508-training/courses/508-basics/index.html" target="_blank">Section 508: What It Is and Why It's Important?</a>** &ndash; Introduction to Section 508 and Information and Communication Technology (ICT). Explains what Section 508 is and why it&rsquo;s important, shows how conformance can make ICT more accessible, reviews job-related responsibilities for meeting Section 508 standards, offers resources to help you meet your Section 508 responsibilities.  
     **Audience**: Anyone interested in learning more about Section 508  
     **Course length**: 1 hour  
     **Certificate or CLPs available?**: Yes
       * <a href="https://training.section508.gov/508-training/courses/508-basics/index.html" target="_blank" aria-label="section508 under why its important">Take this training on Section508.gov</a> to earn a _Certificate of Completion_
-      * [Take this training via FAI][2] to earn <i>CLPs</i> (FAI Course #: FAC 049)<br /><br />
+      * [Take this training via FAI][2] to earn <i>CLPs</i> (FAI Course #: FAC 049)
+  
+  <span id="micro-purchase"></span>
   * **<a href="https://training.section508.gov/508-training/courses/micro-purchase-new/lesson1/index.html" target="_blank">Micro-Purchases and Section 508 Requirements</a>** &ndash; How to make micro-purchases that conform with the Revised 508 Standards, including how the requirements apply to micro-purchases of hardware, software, and other ICT.  
     **Audience**: Government Purchase Card holders, Contracting Officers, Contracting Officer's Representatives (COR), Requiring Officials, Approving Officials and anyone involved in the micro-purchase process  
     **Course length**: 30 minutes  
@@ -58,15 +59,13 @@ The following self-paced courses provide an overview of key aspects of IT access
       * <a href="https://training.section508.gov/508-training/courses/micro-purchase-new/lesson1/index.html" target="_blank" aria-label="training under micropurchase">Take this training on Section508.gov</a> to earn a _Certificate of Completion_
       * [Take this training via FAI][2]&nbsp;to earn <i>CLPs</i> (FAI Course #: FAC 047)
 
-
-
+<span id="playbook"></span>
   * **<a href="https://training.section508.gov/508-training/courses/playbook/index.html" target="_blank"><strong>Technology Accessibility Playbook: How to Build an Effective Section 508 Program</strong></a>** &ndash; Describes the 12 plays to integrate strategic, business and technology management into a successful Section 508 program, to ensure Federal ICT is accessible to persons with disabilities.  
     **Audience**: Section 508 Program Managers; CIO/IT staff; Acquisition staff  
     **Course length**: 2 hours  
     **Certificate or CLPs available?**: No
 
-
-
+<span id="buying-ict"></span>
   * **<a href="https://training.section508.gov/508-training/courses/procurement-new/index.html" target="_blank">Procuring Section 508 Conformant ICT Products and Services</a>** &ndash; Basic overview of the Federal acquisition process with regard to procuring ICT products and services that conform to Section 508.  
     **Audience**: Anyone responsible for ensuring ICT products and services are Section 508 conformant (meet the standards)  
     **Course length**: 1.5 hours  


### PR DESCRIPTION
Updated homepage Quick Links and /training-home/ to allow for deep-link/jump link to micro-purchase course listing so that visitor could chose between 508 course, and FAI course. Added IDs to all courses for future deep linking. 