### PR TITLE
Htaccess update

### DIFF
--- a/assets/images/.htaccess
+++ b/assets/images/.htaccess
@@ -1,6 +1,6 @@
 # Enforce HSTS
 <IfModule mod_headers.c>
-  Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" env=HSTS
 </IfModule>
 
 # Turn off all options we don't need.

--- a/assets/images/.htaccess
+++ b/assets/images/.htaccess
@@ -1,3 +1,8 @@
+# Enforce HSTS
+<IfModule mod_headers.c>
+  Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+</IfModule>
+
 # Turn off all options we don't need.
 Options None
 Options +FollowSymLinks


### PR DESCRIPTION
Adjusting the HTTP Strict Transport Security (HSTS) setting to determine if it resolves the intermittent 'Strict-Transport-Security Header Not Set' error in cloud.gov page scanning reports