### PR TITLE
Updated nokogiri to 1.18.7 to fix High vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.18.3-x64-mingw-ucrt)
+    nokogiri (1.18.7-x64-mingw-ucrt)
       racc (~> 1.4)
     parallel (1.26.3)
     pathutil (0.16.2)


### PR DESCRIPTION
[Preview Link](https://federalist-7a132a2e-6307-4cd0-9f82-e30e871d214a.sites.pages.cloud.gov/preview/gsa/section508.gov/RITM1320064/)

Updated nokogiri to 1.18.7 to fix High vulnerabilities