### PR TITLE
What's New on Section508.gov

### DIFF
--- a/_includes/blog-sidenav.html
+++ b/_includes/blog-sidenav.html
@@ -14,5 +14,6 @@ This sidenav has tags from all the posts. Will be displayed on Blog landing page
 	    {% endfor %}
 	  </ul>
 	</li>
+	<li class="usa-sidenav__item"><a href="{{ site.baseurl }}/whats-new/" class="usa-nav__link {% if page.url == '/whats-new/' %} usa-current{% endif %}">What's New on Section508.gov?</a></li>
   </ul>
 </nav>

--- a/_pages/acquisition/2018-05-29-buy-standards-exceptions.md
+++ b/_pages/acquisition/2018-05-29-buy-standards-exceptions.md
@@ -4,6 +4,7 @@ sidenav: true
 permalink: buy/standards-exceptions/
 type: acquisition
 title: 'Section 508 Standards and Exceptions Chart & Examples'
+description: Learn how Section 508 standards apply to federal IT acquisitions and when exceptions are allowed. Understand compliance requirements, exception types, and agency responsibilities.
 topic: "Acquisition/Buy (buy)"
 sub-topic: "Accessible Acquisition Info, Guidance & Best Practices"
 audience:
@@ -13,7 +14,8 @@ audience:
 resource-type: "Template"
 format: "Document (docx)"
 created: 2018-05-29
-updated: 2025-06-11
+updated: 2025-07-01
+exclude-changelog: true
 ---
 
 When procuring information and communication technology (ICT), ensure your purchases conform to the <a href="https://www.access-board.gov/ict/" target="_blank" class="usa-link--external">Section 508 Standards</a> by clearly communicating the standards and exceptions that apply to **each item** in your solicitation. ICT includes software, hardware, electronic content, support documentation & services. 
@@ -29,7 +31,6 @@ The following examples show how to complete the chart for different ICT items.
   * Website
   * Software
   * Kiosk (complex)
-
 
 <table class="usa-table usa-table--borderless usa-table--striped">
 <caption id="website-example">Table 1: Website Example</caption>

--- a/_pages/acquisition/2025-06-11-buy-understand-exceptions.md
+++ b/_pages/acquisition/2025-06-11-buy-understand-exceptions.md
@@ -4,8 +4,8 @@ sidenav: true
 type: acquisition
 title: Understanding Section 508 Exceptions
 permalink: buy/understanding-section-508-exceptions/
+description: Understand when Section 508 exceptions apply to federal IT purchases. This guide explains types of exceptions, documentation tips, and how to ensure accessible alternatives are provided.
 contributors: usab
-description: 
 audience: 
 - 508-pm
 - buyer

--- a/_pages/create/2018-05-29-create-pdfs.md
+++ b/_pages/create/2018-05-29-create-pdfs.md
@@ -1,11 +1,10 @@
 ---
 layout: page
 sidenav: true
-permalink: create/pdfs/
 type: create
 title: 'Create Accessible PDFs'
-created: 2018-05-29
-updated: 2025-06-23
+permalink: create/pdfs/
+description: Learn how to create accessible PDFs that meet Section 508 standards. Step-by-step guidance for making documents usable by people with disabilities and compliant with federal accessibility requirement
 topic: "Content creation (create)"
 sub-topic: "PDFs"
 audience:
@@ -16,6 +15,8 @@ resource-type: "Process/How-to"
 format: "HTML (html)"
 redirect_from:
 - content/pdfs/
+created: 2018-05-29
+updated: 2025-06-23
 ---
 
 How to create accessible Portable Document Format (PDF) documents that conform to the [Revised 508 Standards][1].

--- a/_pages/create/2018-05-29-create-pdfs.md
+++ b/_pages/create/2018-05-29-create-pdfs.md
@@ -16,7 +16,7 @@ format: "HTML (html)"
 redirect_from:
 - content/pdfs/
 created: 2018-05-29
-updated: 2025-06-23
+updated: 2025-05-23
 ---
 
 How to create accessible Portable Document Format (PDF) documents that conform to the [Revised 508 Standards][1].

--- a/_pages/manage/playbooks/2018-08-15-manage-playbooks-exec-guide-accessibility.md
+++ b/_pages/manage/playbooks/2018-08-15-manage-playbooks-exec-guide-accessibility.md
@@ -4,7 +4,7 @@ layout: page
 permalink: manage/playbooks/exec-guide-accessibility/
 type: manage
 title: 'Executive Guide to Federal IT Accessibility'
-created: 2028-08-15
+created: 2018-08-15
 updated: 2025-03-05
 redirect_from:
 - tools/playbooks/exec-guide-accessibility/

--- a/_pages/tools/2025-03-07-tools-acronyms.md
+++ b/_pages/tools/2025-03-07-tools-acronyms.md
@@ -30,7 +30,7 @@ redirect_from:
 - manage/section-508-assessment/2023/appendix-a-acronyms/
 - manage/section-508-assessment/2024/appendix-a-acronyms/
 created: 2025-03-07
-updated: 2025-03-12
+updated: 2025-06-12
 ---
 These acronyms and abbreviations appear throughout our website, communications, and reports, including the annual [Governmentwide Section 508 Assessment]({{site.baseurl}}/manage/section-508-assessment/annual-reports/) to Congress. Many are defined in [Terms and Definitions]({{site.baseurl}}/tools/glossary/).
 

--- a/_pages/tools/2025-07-01-change-log.md
+++ b/_pages/tools/2025-07-01-change-log.md
@@ -68,7 +68,7 @@ Stay up to date with the latest additions and changes to Section508.gov. This pa
     <li class="usa-icon-list__item">
       <div class="usa-icon-list__icon">
         <svg class="usa-icon" aria-hidden="true" role="img">
-          <use href="/assets/img/sprite.svg#thumb_up_alt"></use>
+          <use href="{{ site.baseurl }}/assets/img/sprite.svg#thumb_up_alt"></use>
         </svg>
       </div>
       <div class="usa-icon-list__content">

--- a/_pages/tools/2025-07-01-change-log.md
+++ b/_pages/tools/2025-07-01-change-log.md
@@ -72,7 +72,7 @@ Stay up to date with the latest additions and changes to Section508.gov. This pa
         </svg>
       </div>
       <div class="usa-icon-list__content">
-        <a href="{{ parts[1] }}">{{ parts[0] }}</a>
+        <a href="{{site.baseurl}}{{ parts[1] }}">{{ parts[0] }}</a>
         {% if parts[3] and parts[3] != "" %}
           &mdash; {{ parts[3] }}
         {% endif %}

--- a/_pages/tools/2025-07-01-change-log.md
+++ b/_pages/tools/2025-07-01-change-log.md
@@ -1,0 +1,85 @@
+---
+layout: post
+sidenav: true
+type: article
+title: What's New on Section508.gov? 
+permalink: whats-new/
+description: "Stay up to date with the latest additions and changes to Section508.gov. This page lists updated content from the past 30 days—making it easy to find new accessibility training, tools, guidance, and policy updates."
+created: 2025-07-01
+exclude-changelog: true
+---
+
+Stay up to date with the latest additions and changes to Section508.gov. This page lists updated content from the past 30 days—making it easy to find new accessibility training, tools, guidance, and policy updates.
+
+{% assign recent_pages = "" | split: "" %}
+{% assign fallback_pages = "" | split: "" %}
+{% assign today = "now" | date: "%s" %}
+{% assign thirty_days_ago = today | minus: 2592000 %}
+
+{%- assign all_entries = site.pages | concat: site.posts -%}
+
+{% for page in all_entries %}
+  {% unless page.exclude-changelog %}
+    {% assign created_epoch = page.created | date: "%s" | plus: 0 %}
+    {% if page.updated %}
+      {% assign updated_epoch = page.updated | date: "%s" | plus: 0 %}
+    {% else %}
+      {% assign updated_epoch = created_epoch %}
+    {% endif %}
+
+    {% if updated_epoch > created_epoch %}
+      {% assign most_recent_epoch = updated_epoch %}
+    {% else %}
+      {% assign most_recent_epoch = created_epoch %}
+    {% endif %}
+
+    {% assign most_recent_date = most_recent_epoch | plus: 0 %}
+    {% assign display_date = page.updated | default: page.created %}
+    {% assign description = page.description | strip | replace: "|", "&#124;" %}
+
+    {%- comment -%}
+    Pack: title|url|date|description|epoch
+    {%- endcomment -%}
+    {% assign packed = page.title | append: "|" | append: page.url | append: "|" | append: display_date | append: "|" | append: description | append: "|" | append: most_recent_date %}
+
+    {% if most_recent_date >= thirty_days_ago %}
+      {% assign recent_pages = recent_pages | push: packed %}
+    {% endif %}
+
+    {% assign fallback_pages = fallback_pages | push: packed %}
+  {% endunless %}
+{% endfor %}
+
+{% assign sorted_recent = recent_pages | sort_natural | reverse %}
+{% assign sorted_fallback = fallback_pages | sort_natural | reverse %}
+
+{% assign recent_count = sorted_recent.size %}
+{% if recent_count == 0 %}
+  {% assign display_items = sorted_fallback %}
+  {% assign display_limit = 5 %}
+{% else %}
+  {% assign display_items = sorted_recent %}
+  {% assign display_limit = recent_count %}
+{% endif %}
+
+<ul class="list-item-spacer">
+  {% for item in display_items limit:display_limit %}
+    {% assign parts = item | split: "|" %}
+    <li class="usa-icon-list__item">
+      <div class="usa-icon-list__icon">
+        <svg class="usa-icon" aria-hidden="true" role="img">
+          <use href="/assets/img/sprite.svg#thumb_up_alt"></use>
+        </svg>
+      </div>
+      <div class="usa-icon-list__content">
+        <a href="{{ parts[1] }}">{{ parts[0] }}</a>
+        {% if parts[3] and parts[3] != "" %}
+          &mdash; {{ parts[3] }}
+        {% endif %}
+        ({{ parts[4] | date: "%B %Y" }})
+      </div>
+    </li>
+  {% endfor %}
+</ul>
+
+**Reviewed/Updated:** {{ today | date: "%B %Y" }}

--- a/_pages/training/2018-05-08-tools-coordinator-listing.md
+++ b/_pages/training/2018-05-08-tools-coordinator-listing.md
@@ -4,6 +4,7 @@ sidenav: true
 type: training
 title: 'Find Your Section 508 Program Manager'
 permalink: tools/program-manager-listing/
+description: "Find your agency’s Section 508 Program Manager using this official U.S. government directory. Connect with accessibility leads to support IT compliance with federal accessibility standards."
 redirect_from:
 - tools/coordinator-listing/
 - 508-coordinator-listing/


### PR DESCRIPTION
Propose adding this change log to the Blogs & Updates page. The logic includes all pages and blogs created or updated in the last 30 days. If no pages have been updated in that time, the 5 most current pages will be displayed. A new front matter value—exclude-changelog—was created as part of this update to allow authors to exclude a page or post to be excluded where the update does rise to notification, e.g., broken link or other bug fix. 