### PR TITLE
Add content library

### DIFF
--- a/_includes/library-cards.html
+++ b/_includes/library-cards.html
@@ -1,0 +1,144 @@
+<!--******* Generates content library/catalog item cards. ********-->
+
+<div class="tablet:grid-col-9">
+    <h2>Content Library Cards</h2>
+    <div id="filter-count-container" class="margin-bottom-2">
+        <p id="filter-count-text" aria-live="polite" aria-atomic="true">
+            <span id="filter-count" class="filter-count card-tag margin-top-0 text-gray-50 text-thin">X </span>
+            ITEMS SELECTED
+        </p>
+    </div>
+    {% assign topics = site.pages  | map: "topic" | uniq | compact | sort %}
+    {% assign sub-topics = site.pages  | map: "sub-topic" | uniq | compact | sort %}
+    {% assign audience = site.pages  | map: "audience" | uniq | compact | sort %}
+    {% assign resource-types = site.pages  | map: "resource-type" | uniq | compact | sort %}
+    {% assign formats = site.pages  | map: "format" | uniq | compact | sort %}
+    <div id="active-filters-container" class="margin-bottom-2">
+        <p id="active-filters">Active Filters: <span id="no-filters" class="text-primary-vivid">None</span>
+                <ul id="active-filters-list" class="active-filters-list">
+                    {% for item in topics %}
+                        {% assign split_item = item | split: " (" %}
+                        {% assign filter = split_item[0] %}
+                        {% if filter == "Other" %}
+                            {% assign fil = filter | downcase %}
+                        {% else %}
+                            {% assign fil = split_item[1] | replace: ")", "" %}
+                        {% endif %}
+                        <li class="active-fliter-item bg-secondary-lighter border-solid radius-pill border-primary-vivid border-width-1px padding-left-05 padding-right-1 display-none" data-filter="{{fil}}"><a aria-label="Remove filter by Topic: {{filter}}" href="javascript:void(0)">
+                            <svg class="usa-icon text-middle margin-bottom-05 text-secondary-darker" aria-hidden="true" focusable="false" role="img">
+                                <use href="{{site.baseurl}}/assets/img/sprite.svg#highlight_off"></use>
+                            </svg>
+                            {{filter}}
+                            </a>
+                        </li>
+                    {% endfor %}
+                    {% for item in sub-topics %}
+                        {% assign filter = item %}
+                        {% assign fil = item | downcase | replace: " ","-" | replace: "/","-" | replace: ",","" %}
+                        <li class="active-fliter-item bg-secondary-lighter border-solid radius-pill border-primary-vivid border-width-1px padding-left-05 padding-right-1 display-none" data-filter="{{fil}}"><a aria-label="Remove filter by Sub-topic: {{filter}}" href="javascript:void(0)">
+                            <svg class="usa-icon text-middle margin-bottom-05 text-secondary-darker" aria-hidden="true" focusable="false" role="img">
+                                <use href="{{site.baseurl}}/assets/img/sprite.svg#highlight_off"></use>
+                            </svg>
+                            {{filter}}
+                            </a>
+                        </li>
+                    {% endfor %}
+                    {% for item in audience %}
+                        {% assign split_item = item | split: " (" %}
+                        {% assign filter = split_item[0] %}
+                        {% assign fil = split_item[1] | replace: ")", "" %}
+                        <li class="active-fliter-item bg-secondary-lighter border-solid radius-pill border-primary-vivid border-width-1px padding-left-05 padding-right-1 display-none" data-filter="{{fil}}"><a aria-label="Remove filter by Audience: {{filter}}" href="javascript:void(0)">
+                            <svg class="usa-icon text-middle margin-bottom-05 text-secondary-darker" aria-hidden="true" focusable="false" role="img">
+                                <use href="{{site.baseurl}}/assets/img/sprite.svg#highlight_off"></use>
+                            </svg>
+                            {{filter}}
+                            </a>
+                        </li>
+                    {% endfor %}
+                    {% for item in resource-types %}
+                        {% assign split_item = item | split: " (" %}
+                        {% assign filter = split_item[0] %}
+                        {% assign fil = filter | downcase | replace: " ","-" | replace: "/","-" %}
+                        <li class="active-fliter-item bg-secondary-lighter border-solid radius-pill border-primary-vivid border-width-1px padding-left-05 padding-right-1 display-none" data-filter="{{fil}}"><a aria-label="Remove filter by Resource Type: {{filter}}" href="javascript:void(0)">
+                            <svg class="usa-icon text-middle margin-bottom-05 text-secondary-darker" aria-hidden="true" focusable="false" role="img">
+                                <use href="{{site.baseurl}}/assets/img/sprite.svg#highlight_off"></use>
+                            </svg>
+                            {{filter}}
+                            </a>
+                        </li>
+                    {% endfor %}
+                    {% for item in formats %}
+                        {% assign split_item = item | split: " (" %}
+                        {% assign filter = split_item[0] %}
+                        {% assign fil = split_item[1] | replace: ")", "" %}
+                        <li class="active-fliter-item bg-secondary-lighter border-solid radius-pill border-primary-vivid border-width-1px padding-left-05 padding-right-1 display-none" data-filter="{{fil}}"><a aria-label="Remove filter by Format: {{filter}}" href="javascript:void(0)">
+                            <svg class="usa-icon text-middle margin-bottom-05 text-secondary-darker" aria-hidden="true" focusable="false" role="img">
+                                <use href="{{site.baseurl}}/assets/img/sprite.svg#highlight_off"></use>
+                            </svg>
+                            {{filter}}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+        </p>
+    </div>
+    <ul id="library-cards" class="usa-card-group">
+        {% for page in site.pages %}
+        {% if page.library-exclude %}
+        {% else %}
+
+            {% comment %} !!! Assign each card filter and filter shorthand from topic, sub-topic, audience, resource type, and format !!! {% endcomment %}
+        
+            {% assign topic_item = page.topic %}
+            {% assign topic_split_item = topic_item | split: " (" %}
+            {% assign topic_filter = topic_split_item[0] %}
+            {% if topic_str_filter == "Other" %}
+                {% assign topic_fil = topic_filter | downcase %}
+            {% else %}
+                {% assign topic_short_fil = topic_split_item[1] %}
+                {% assign topic_fil = topic_short_fil | replace: ")", "" %}
+            {% endif %}
+
+            {% assign sub-topic_filter = page.sub-topic %}
+            {% assign sub-topic_fil = sub-topic_filter | downcase | replace: " ","-" | replace: "/","-" | replace: ",","" %}
+            
+            {% assign audience_filter = "" %}
+            {% assign audience_fil = "" %}
+            {% for item in page.audience %}
+                {% assign split_item = item | split: " (" %}
+                {% assign label = split_item[0] %}
+                {% assign short = split_item[1] | replace: ")", "" %}
+
+                {% if forloop.first %}
+                    {% assign audience_filter = label %}
+                    {% assign audience_fil = short %}
+                {% else %}
+                    {% assign audience_filter = audience_filter | append: ", " | append: label %}
+                    {% assign audience_fil = audience_fil | append: ", " | append: short %}
+                {% endif %}
+            {% endfor %}
+
+            {% assign resource_type_split_item = page.resource-type | split: " (" %}
+            {% assign resource_type_filter = resource_type_split_item[0] %}
+            {% assign resource_type_fil = resource_type_filter | downcase | replace: " ","-" | replace: "/","-" %}
+
+            {% assign format_split_item = page.format | split: " (" %}
+            {% assign format_filter = format_split_item[0] %}
+            {% assign format_fil = format_split_item[1] | replace: ")", "" %}
+
+        <li class="usa-card grid-col-12 tablet:grid-col-6 desktop:grid-col-4" data-topic="{{ topic_fil }}" data-sub_topic="{{ sub-topic_fil }}"  data-audience="{{ audience_fil }}" data-resource_type="{{ resource_type_fil }}" data-format="{{ format_fil }}">
+            <div class="usa-card__container">
+                <div class="usa-card__header padding-top-1 bg-primary-lighter">
+                    <span class="usa-card__heading font-sans-md text-bold">{{topic_filter}}</span>
+                </div>
+                <div class="usa-card__body">
+                    <p class="font-sans-sm">
+                        <a class="no-style" href="{{ site.baseurl }}/{{ page.permalink }}">{{ page.title }}</a>
+                    </p>
+                </div>
+            </div>
+        </li>
+        {% endif %}
+        {% endfor %}
+    </ul>
+</div>

--- a/_includes/library-cards.html
+++ b/_includes/library-cards.html
@@ -8,11 +8,12 @@
             ITEMS SELECTED
         </p>
     </div>
-    {% assign topics = site.pages  | map: "topic" | uniq | compact | sort %}
-    {% assign sub-topics = site.pages  | map: "sub-topic" | uniq | compact | sort %}
-    {% assign audience = site.pages  | map: "audience" | uniq | compact | sort %}
-    {% assign resource-types = site.pages  | map: "resource-type" | uniq | compact | sort %}
-    {% assign formats = site.pages  | map: "format" | uniq | compact | sort %}
+    {% assign pages_posts = site.pages | concat: site.posts %}
+    {% assign topics = pages_posts | map: "topic" | uniq | compact | sort %}
+    {% assign sub-topics = pages_posts | map: "sub-topic" | uniq | compact | sort %}
+    {% assign audience = pages_posts | map: "audience" | uniq | compact | sort %}
+    {% assign resource-types = pages_posts | map: "resource-type" | uniq | compact | sort %}
+    {% assign formats = pages_posts | map: "format" | uniq | compact | sort %}
     <div id="active-filters-container" class="margin-bottom-2">
         <p id="active-filters">Active Filters: <span id="no-filters" class="text-primary-vivid">None</span>
                 <ul id="active-filters-list" class="active-filters-list">
@@ -83,7 +84,7 @@
         </p>
     </div>
     <ul id="library-cards" class="usa-card-group">
-        {% for page in site.pages %}
+        {% for page in pages_posts %}
         {% if page.library-exclude %}
         {% else %}
 

--- a/_includes/library-cards.html
+++ b/_includes/library-cards.html
@@ -92,7 +92,7 @@
             {% assign topic_item = page.topic %}
             {% assign topic_split_item = topic_item | split: " (" %}
             {% assign topic_filter = topic_split_item[0] %}
-            {% if topic_str_filter == "Other" %}
+            {% if topic_filter == "Other" %}
                 {% assign topic_fil = topic_filter | downcase %}
             {% else %}
                 {% assign topic_short_fil = topic_split_item[1] %}

--- a/_includes/library-filters.html
+++ b/_includes/library-filters.html
@@ -1,0 +1,201 @@
+<!--*********** Filter buttons for content library page *****************-->
+
+<div class="tablet:grid-col-3">
+
+    <a id="reset-filters" class="usa-button usa-button--accent-cool margin-bottom-2" href="javascript:void(0)">Reset Filter</a>
+
+    {% assign topics = site.pages  | map: "topic" | uniq | compact | sort %}
+    {% assign sub-topics = site.pages  | map: "sub-topic" | uniq | compact | sort %}
+    {% assign audience = site.pages  | map: "audience" | uniq | compact | sort %}
+    {% assign resource-types = site.pages  | map: "resource-type" | uniq | compact | sort %}
+    {% assign formats = site.pages  | map: "format" | uniq | compact | sort %}
+
+    <nav id="filter" class="filters" aria-label="Filters">
+        <div class="usa-accordion">
+            <form class="usa-form margin-y-1">
+                <fieldset class="usa-fieldset filter-list" data-filter-group="topic">
+                    <legend class="usa-label width-full">
+                        <h2 class="filter-title font-sans-sm usa-accordion__heading">
+                            <button
+                            type="button"
+                            class="usa-accordion__button"
+                            aria-expanded="false"
+                            aria-controls="topic-filters"
+                            >
+                            Filter by Topic
+                            </button>
+                        </h2>
+                    </legend>
+                    <div id="topic-filters" class="usa-accordion__content padding-y-05 padding-x-0 margin-top-05">
+                        {% for item in topics %}
+                            {% assign split_item = item | split: " (" %}
+                            {% assign filter = split_item[0] %}
+                            {% if filter == "Other" %}
+                                {% assign fil = filter | downcase %}
+                            {% else %}
+                                {% assign fil = split_item[1] | replace: ")", "" %}
+                            {% endif %}
+                        <div class="usa-checkbox filter-item margin-2px">
+                            <input
+                                class="usa-checkbox__input usa-checkbox__input--tile"
+                                id="check-{{fil}}-{% increment counter1 %}"
+                                type="checkbox"
+                                name="{{fil}}"
+                                value="{{fil}}"
+                                data-filter="{{fil}}"
+                            />
+                            <label class="usa-checkbox__label font-sans-xs" for="check-{{fil}}-{% increment counter2 %}"
+                                >{{filter}}</label
+                            >
+                        </div>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                </fieldset>
+
+                <fieldset class="usa-fieldset filter-list margin-y-1" data-filter-group="sub_topic">
+                    <legend class="usa-label width-full">
+                        <h2 class="filter-title font-sans-sm usa-accordion__heading">
+                            <button
+                            type="button"
+                            class="usa-accordion__button"
+                            aria-expanded="false"
+                            aria-controls="sub-topic-filters"
+                            >
+                            Filter by Sub-Topic
+                        </button>
+                    </h2>
+                    </legend>
+                    <div id="sub-topic-filters" class="usa-accordion__content padding-y-05 padding-x-0 margin-top-05">
+                        {% for item in sub-topics %}
+                        {% assign filter = item %}
+                        {% assign fil = filter | downcase | replace: " ","-" | replace: "/","-" | replace: ",","" %}
+                        <div class="usa-checkbox filter-item margin-2px">
+                            <input
+                                class="usa-checkbox__input usa-checkbox__input--tile"
+                                id="check-{{fil}}-{% increment counter1 %}"
+                                type="checkbox"
+                                name="{{fil}}"
+                                value="{{fil}}"
+                                data-filter="{{fil}}"
+                            />
+                            <label class="usa-checkbox__label font-sans-xs" for="check-{{fil}}-{% increment counter2 %}"
+                                >{{filter}}</label
+                            >
+                        </div>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                </fieldset>
+
+                <fieldset class="usa-fieldset filter-list margin-y-1" data-filter-group="audience">
+                    <legend class="usa-label width-full">
+                        <h2 class="filter-title font-sans-sm usa-accordion__heading">
+                            <button
+                            type="button"
+                            class="usa-accordion__button"
+                            aria-expanded="false"
+                            aria-controls="audience-filters"
+                            >
+                            Filter by Audience
+                        </button>
+                    </h2>
+                    </legend>
+                    <div id="audience-filters" class="usa-accordion__content padding-y-05 padding-x-0 margin-top-05">
+                        {% for item in audience %}
+                            {% assign split_item = item | split: " (" %}
+                            {% assign filter = split_item[0] %}
+                            {% assign fil = split_item[1] | replace: ")", "" %}
+                        <div class="usa-checkbox filter-item margin-2px">
+                            <input
+                                class="usa-checkbox__input usa-checkbox__input--tile"
+                                id="check-{{fil}}-{% increment counter1 %}"
+                                type="checkbox"
+                                name="{{fil}}"
+                                value="{{fil}}"
+                                data-filter="{{fil}}"
+                            />
+                            <label class="usa-checkbox__label font-sans-xs" for="check-{{fil}}-{% increment counter2 %}"
+                                >{{filter}}</label
+                            >
+                        </div>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                </fieldset>
+
+                <fieldset class="usa-fieldset filter-list margin-y-1" data-filter-group="resource_type">
+                    <legend class="usa-label width-full">
+                        <h2 class="filter-title font-sans-sm usa-accordion__heading">
+                            <button
+                            type="button"
+                            class="usa-accordion__button"
+                            aria-expanded="false"
+                            aria-controls="resource-type-filters"
+                            >
+                            Filter by Resource Type
+                        </button>
+                    </h2>
+                    </legend>
+                    <div id="resource-type-filters" class="usa-accordion__content padding-y-05 padding-x-0 margin-top-05">
+                         {% for item in resource-types %}
+                            {% assign split_item = item | split: " (" %}
+                            {% assign filter = split_item[0] %}
+                            {% assign fil = filter | downcase | replace: " ","-" | replace: "/","-" %}
+                        <div class="usa-checkbox filter-item margin-2px">
+                            <input
+                                class="usa-checkbox__input usa-checkbox__input--tile"
+                                id="check-{{fil}}-{% increment counter1 %}"
+                                type="checkbox"
+                                name="{{fil}}"
+                                value="{{fil}}"
+                                data-filter="{{fil}}"
+                            />
+                            <label class="usa-checkbox__label font-sans-xs" for="check-{{fil}}-{% increment counter2 %}"
+                                >{{filter}}</label
+                            >
+                        </div>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                </fieldset>
+
+                <fieldset class="usa-fieldset filter-list margin-y-1" data-filter-group="format">
+                    <legend class="usa-label width-full">
+                        <h2 class="filter-title font-sans-sm usa-accordion__heading">
+                            <button
+                            type="button"
+                            class="usa-accordion__button"
+                            aria-expanded="false"
+                            aria-controls="format-filters"
+                            >
+                            Filter by Format
+                        </button>
+                    </h2>
+                    </legend>
+                    <div id="format-filters" class="usa-accordion__content padding-y-05 padding-x-0 margin-top-05">
+                         {% for item in formats %}
+                            {% assign split_item = item | split: " (" %}
+                            {% assign filter = split_item[0] %}
+                            {% assign fil = split_item[1] | replace: ")", "" %}
+                        <div class="usa-checkbox filter-item margin-2px">
+                            <input
+                                class="usa-checkbox__input usa-checkbox__input--tile"
+                                id="check-{{fil}}-{% increment counter1 %}"
+                                type="checkbox"
+                                name="{{fil}}"
+                                value="{{fil}}"
+                                data-filter="{{fil}}"
+                            />
+                            <label class="usa-checkbox__label font-sans-xs" for="check-{{fil}}-{% increment counter2 %}"
+                                >{{filter}}</label
+                            >
+                        </div>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                </fieldset>
+            </form>
+        </div>
+    </nav>
+</div>

--- a/_includes/library-filters.html
+++ b/_includes/library-filters.html
@@ -35,6 +35,7 @@
                             {% else %}
                                 {% assign fil = split_item[1] | replace: ")", "" %}
                             {% endif %}
+                            {% if fil != "" %}
                         <div class="usa-checkbox filter-item margin-2px">
                             <input
                                 class="usa-checkbox__input usa-checkbox__input--tile"
@@ -48,6 +49,7 @@
                                 >{{filter}}</label
                             >
                         </div>
+                            {% endif %}
                         {% endfor %}
                         </ul>
                     </div>
@@ -68,8 +70,9 @@
                     </legend>
                     <div id="sub-topic-filters" class="usa-accordion__content padding-y-05 padding-x-0 margin-top-05">
                         {% for item in sub-topics %}
-                        {% assign filter = item %}
-                        {% assign fil = filter | downcase | replace: " ","-" | replace: "/","-" | replace: ",","" %}
+                            {% assign filter = item %}
+                            {% assign fil = filter | downcase | replace: " ","-" | replace: "/","-" | replace: ",","" %}
+                            {% if fil != "" %}
                         <div class="usa-checkbox filter-item margin-2px">
                             <input
                                 class="usa-checkbox__input usa-checkbox__input--tile"
@@ -83,6 +86,7 @@
                                 >{{filter}}</label
                             >
                         </div>
+                            {% endif %}
                         {% endfor %}
                         </ul>
                     </div>
@@ -106,6 +110,7 @@
                             {% assign split_item = item | split: " (" %}
                             {% assign filter = split_item[0] %}
                             {% assign fil = split_item[1] | replace: ")", "" %}
+                            {% if fil != "" %}
                         <div class="usa-checkbox filter-item margin-2px">
                             <input
                                 class="usa-checkbox__input usa-checkbox__input--tile"
@@ -119,6 +124,7 @@
                                 >{{filter}}</label
                             >
                         </div>
+                            {% endif %}
                         {% endfor %}
                         </ul>
                     </div>
@@ -142,6 +148,7 @@
                             {% assign split_item = item | split: " (" %}
                             {% assign filter = split_item[0] %}
                             {% assign fil = filter | downcase | replace: " ","-" | replace: "/","-" %}
+                            {% if fil != "" %}
                         <div class="usa-checkbox filter-item margin-2px">
                             <input
                                 class="usa-checkbox__input usa-checkbox__input--tile"
@@ -155,6 +162,7 @@
                                 >{{filter}}</label
                             >
                         </div>
+                            {% endif %}
                         {% endfor %}
                         </ul>
                     </div>
@@ -178,6 +186,7 @@
                             {% assign split_item = item | split: " (" %}
                             {% assign filter = split_item[0] %}
                             {% assign fil = split_item[1] | replace: ")", "" %}
+                            {% if fil != "" %}
                         <div class="usa-checkbox filter-item margin-2px">
                             <input
                                 class="usa-checkbox__input usa-checkbox__input--tile"
@@ -191,6 +200,7 @@
                                 >{{filter}}</label
                             >
                         </div>
+                            {% endif %}
                         {% endfor %}
                         </ul>
                     </div>

--- a/_includes/library-filters.html
+++ b/_includes/library-filters.html
@@ -4,11 +4,12 @@
 
     <a id="reset-filters" class="usa-button usa-button--accent-cool margin-bottom-2" href="javascript:void(0)">Reset Filter</a>
 
-    {% assign topics = site.pages  | map: "topic" | uniq | compact | sort %}
-    {% assign sub-topics = site.pages  | map: "sub-topic" | uniq | compact | sort %}
-    {% assign audience = site.pages  | map: "audience" | uniq | compact | sort %}
-    {% assign resource-types = site.pages  | map: "resource-type" | uniq | compact | sort %}
-    {% assign formats = site.pages  | map: "format" | uniq | compact | sort %}
+    {% assign pages_posts = site.pages | concat: site.posts %}
+    {% assign topics = pages_posts | map: "topic" | uniq | compact | sort %}
+    {% assign sub-topics = pages_posts | map: "sub-topic" | uniq | compact | sort %}
+    {% assign audience = pages_posts | map: "audience" | uniq | compact | sort %}
+    {% assign resource-types = pages_posts | map: "resource-type" | uniq | compact | sort %}
+    {% assign formats = pages_posts | map: "format" | uniq | compact | sort %}
 
     <nav id="filter" class="filters" aria-label="Filters">
         <div class="usa-accordion">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -42,3 +42,10 @@
     }); 
   });
 </script>
+
+{% if page.custom-script %}
+<!-- Custom Page Scripts -->
+{% for script in page.custom-script %}
+<script src="{{site.baseurl}}/assets/js/{{script}}"></script>
+{% endfor %}
+{% endif %}

--- a/_pages/content-pages/content-library.html
+++ b/_pages/content-pages/content-library.html
@@ -1,0 +1,30 @@
+---
+title: Content Library
+description: This content library helps users filter and find content contained on Section508.gov by topic, audience, resource type, and format.
+subtitle: Our Focus Areas
+layout: page
+permalink: /content-library/
+sidenav: false
+custom-script: content-library.js
+library-exclude: true
+---
+<section class="usa-graphic-list">
+  <div class="grid-container padding-x-1">
+    <div class="usa-graphic-list__row grid-row grid-gap">
+
+        <p class="font-sans-sm margin-y-0"><span id="long-intro" class="display-none tablet:display-inline">Use the filters below to explore our content library. You can narrow results by Topic, Sub-Topic, Audience, Resource Type, and Format. Select one or more filters in each group to expand the results, and combine filters across different groups to refine your search. As you make selections, the list of matching items and active filters will update automatically. You can reset all filters at any time, and use the filter link in your browser’s address bar to bookmark or share specific views.</span><span id="short-intro" class="tablet:display-none">Filter content by Topic, Audience, Format, and more. Choose multiple filters to expand or refine your results. The list updates automatically as you go. Use the Reset button to clear filters or share the link to save your view.</span></p>
+<br>
+    </div>
+  </div>
+</section>
+
+<section class="usa-graphic-list margin-bottom-4">
+  <div class="grid-container padding-x-1">
+    <div class="usa-graphic-list__row grid-row grid-gap">
+
+      {% include library-filters.html %}
+      {% include library-cards.html %}
+
+    </div>
+  </div>
+</section>

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -41,7 +41,7 @@
 }
 
 a{
-  color: #054299;
+  color: #1763cf;
 }
 
 .card-tag {
@@ -1620,3 +1620,122 @@ div[role=rowheader] {
   display: inline-block; 
   margin-left: 48px;
 }
+
+/******** Styling for content library ********/
+/* Adjust spacing without checkbox */
+.usa-checkbox__input--tile+[class*=__label] {
+  display: inline-block !important;
+  padding: 0.25rem;
+  margin: 0;
+  border: 0;
+}
+
+.usa-checkbox__input--tile:checked+[class*=__label] {
+  background-color: #e6eff6;
+  border: 2px solid #005ea2;
+  border-radius: 0.25rem;
+}
+
+/* Library Card transitions */
+#library-cards li {
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+/* Hide checkbox */
+.usa-checkbox__label::before {
+  display: none;
+}
+
+.filter-list {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.filter-item {
+  display: inline-block!important;
+  border: 1px solid #005ea2;
+  border-radius: 0.25rem;
+}
+
+.filter-item:focus-within {
+  border: .25rem solid #2491ff;
+  border-radius: 0.25rem;
+}
+
+/* Content Library - remove default list styling */
+.active-filters-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em; /* optional: space between items */
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.active-filters-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* Content Library inline list items */
+.active-filter-item {
+  display: inline-block !important;
+  margin-right: 0.5em;
+  text-decoration: none !important;
+}
+
+/* Content Library - remove bullet from any nested <li> */
+.active-filters-list li::marker {
+  display: none;
+  content: none;
+}
+
+/* Style the link inside the list item */
+.active-filters-list a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.card-tag {
+  font-size: .9rem;
+  margin-top: .2em;
+  margin-bottom: .15em;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: #323a45;
+ }
+
+.no-style {
+  text-decoration: none;
+  color: black;
+}
+
+.filters ul {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+}
+
+.filters li {
+    margin: 0 2px 2px 0;
+}
+
+.filters a {
+    display: block;
+    padding: .5em 1em;
+    font-size: 80%;
+    border: solid 1px hsl(0, 0%, 50%);
+    color: #333;
+    text-decoration: none;
+    background: white;
+}
+
+
+.filters a:hover {
+    outline: 2px solid hsl(0, 0%, 50%);
+}
+

--- a/assets/js/content-library.js
+++ b/assets/js/content-library.js
@@ -1,0 +1,197 @@
+document.addEventListener("DOMContentLoaded", function () {
+  function getFiltersFromURL() {
+    const params = new URLSearchParams(window.location.search);
+    const filters = {};
+
+    for (const [key, value] of params.entries()) {
+      if (!filters[key]) filters[key] = [];
+      filters[key].push(value);
+    }
+
+    return filters;
+  }
+
+  function applyURLFilters() {
+    const urlFilters = getFiltersFromURL();
+
+    checkboxes.forEach(cb => {
+      const group = cb.closest("fieldset")?.dataset.filterGroup;
+      const value = cb.dataset.filter;
+
+      if (group && value && urlFilters[group]?.includes(value)) {
+        cb.checked = true;
+      } else {
+        cb.checked = false;
+      }
+    });
+  }
+
+  const checkboxes = document.querySelectorAll("#filter input[type='checkbox']");
+  const cards = document.querySelectorAll("#library-cards li");
+  const pillContainer = document.getElementById("active-filters-list");
+  const noFiltersText = document.getElementById("no-filters");
+  const resetButton = document.getElementById("reset-filters");
+  const countSpan = document.getElementById("filter-count");
+
+  const filterAttributes = {
+    topic: "data-topic",
+    sub_topic: "data-sub_topic",
+    audience: "data-audience",
+    resource_type: "data-resource_type",
+    format: "data-format"
+  };
+
+  // Group selected filters by their filter group
+  function getGroupedFilters() {
+    const groups = {};
+    checkboxes.forEach(cb => {
+      if (cb.checked && cb.dataset.filter && cb.closest("fieldset")?.dataset.filterGroup) {
+        const group = cb.closest("fieldset").dataset.filterGroup;
+        if (!groups[group]) groups[group] = [];
+        groups[group].push(cb.dataset.filter);
+      }
+    });
+    return groups;
+  }
+
+  function matchesGroup(card, groupName, groupValues) {
+    const attr = filterAttributes[groupName];
+    if (!attr) return true;
+
+    const cardAttrVal = card.getAttribute(attr) || "";
+    const cardValues = cardAttrVal.split(",").map(s => s.trim());
+    return groupValues.some(value => cardValues.includes(value));
+  }
+
+  function matchesAllGroups(card, groupedFilters) {
+    return Object.entries(groupedFilters).every(([groupName, groupValues]) =>
+      matchesGroup(card, groupName, groupValues)
+    );
+  }
+
+  function updateFilterPills(groupedFilters) {
+    const activeValues = Object.values(groupedFilters).flat();
+    const pillItems = pillContainer.querySelectorAll("li[data-filter]");
+    let anyVisible = false;
+
+    pillItems.forEach(pill => {
+      const isActive = activeValues.includes(pill.dataset.filter);
+      pill.classList.toggle("display-none", !isActive);
+      if (isActive) anyVisible = true;
+    });
+
+    noFiltersText.classList.toggle("display-none", anyVisible);
+  }
+
+  function updateCardCount() {
+    const visibleCards = Array.from(cards).filter(card => !card.classList.contains("display-none"));
+    if (countSpan) {
+      countSpan.textContent = visibleCards.length;
+    }
+  }
+
+  applyURLFilters();  // <-- load filters from URL
+  updateFilterUI();   // then apply them visually
+
+  function updateFilterUI() {
+    const groupedFilters = getGroupedFilters();
+    updateFilterPills(groupedFilters);
+
+    cards.forEach(card => {
+      const isMatch = matchesAllGroups(card, groupedFilters);
+
+      if (isMatch) {
+        card.classList.remove("display-none");
+        card.style.opacity = "1";
+        card.style.transform = "scale(1)";
+        card.style.pointerEvents = "auto";
+      } else {
+        card.style.opacity = "0";
+        card.style.transform = "scale(0.95)";
+        card.style.pointerEvents = "none";
+        setTimeout(() => card.classList.add("display-none"), 200);
+      }
+    });
+
+    setTimeout(updateCardCount, 210);
+    updateCheckboxStates(groupedFilters); // disable unavailable filters
+    updateURLFromFilters(groupedFilters); // Update URL with current filters
+  }
+
+  function updateCheckboxStates(groupedFilters) {
+    checkboxes.forEach(cb => {
+      const group = cb.closest("fieldset")?.dataset.filterGroup;
+      const value = cb.dataset.filter;
+      if (!group || !value) return;
+
+      // Always keep selected filters enabled
+      if (cb.checked) {
+        cb.disabled = false;
+        return;
+      }
+
+      // Create a test filter state:
+      // Keep all other groups, but replace this group with only the checkbox's value
+      const testFilters = { ...groupedFilters, [group]: [value] };
+
+      const hasMatches = Array.from(cards).some(card => {
+        return matchesAllGroups(card, testFilters);
+      });
+
+      cb.disabled = !hasMatches;
+    });
+  }
+
+  // Listen for checkbox changes
+  checkboxes.forEach(cb => {
+    cb.addEventListener("change", updateFilterUI);
+    // Add Enter key support
+    cb.addEventListener("keydown", function (e) {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        cb.checked = !cb.checked;
+        updateFilterUI();
+      }
+    });
+  });
+  
+
+  // Remove filter when clicking a pill
+  pillContainer.addEventListener("click", function (e) {
+    const anchor = e.target.closest("a");
+    const pillLi = anchor?.closest("li[data-filter]");
+    if (pillLi) {
+      e.preventDefault();
+      const filterVal = pillLi.dataset.filter;
+      const checkbox = document.querySelector(`#filter input[data-filter='${filterVal}']`);
+      if (checkbox) {
+        checkbox.checked = false;
+        updateFilterUI();
+      }
+    }
+  });
+
+  // Reset all checkboxes
+  if (resetButton) {
+    resetButton.addEventListener("click", function (e) {
+      e.preventDefault();
+      checkboxes.forEach(cb => {
+        cb.checked = false;
+      });
+      updateFilterUI();
+    });
+  }
+
+  function updateURLFromFilters(groupedFilters) {
+    const params = new URLSearchParams();
+
+    for (const [group, values] of Object.entries(groupedFilters)) {
+      values.forEach(value => params.append(group, value));
+    }
+
+    const newURL = window.location.pathname + '?' + params.toString();
+    history.replaceState(null, '', newURL); // don't reload
+  }
+
+  updateFilterUI(); // Run on load
+});


### PR DESCRIPTION
Content Library includes the following features and functions:
- Dynamic filtering of "library cards" across multiple filters, including topic, sub-topic, audience, resource type, and format
- And/Or logic for additive (or) filters within a filter type/category and reductive (and) filters between filter types/categories
- Active filters list pill boxes with the ability to remove individual filters from the filter selection accordions or from the active filters list pill boxes
- Filters reset to remove all filters at once
- URL parameters for each filter, to make it possible to bookmark and share filters
- Dynamic disabling of filters when filters become unavailable (or wouldn't make any difference if selected) based on the current  filter selection

Still to do:
- Fix front matter inconsistencies, including misspellings, duplicate alternative filters, articles/pages with missing or bad filter parameters in front matter, add library-exclude: true to certain additional pages
- Consider possible color schemes for library card categories/filters