### PR TITLE
Update URL for Procurement Guidae Part 2

### DIFF
--- a/_data/sidenav.yaml
+++ b/_data/sidenav.yaml
@@ -601,7 +601,7 @@ acquisition:
           - name: "Accessibility In Procurement I: Pre-Soliciation"
             url: 'buy/accessibility-in-procurement-pre-solicitation-1/'
           - name: "Accessibility In Procurement II: Soliciation & Post-Solicitation"
-            url: 'buy/accessibility-in-procurement-pre-solicitation-2/'         
+            url: 'buy/accessibility-in-procurement-solicitation-post-2/'         
   - name: Sell
     url: '#'
     children:

--- a/_pages/acquisition/2023-09-25-buy-accessibility-in-procurement2.md
+++ b/_pages/acquisition/2023-09-25-buy-accessibility-in-procurement2.md
@@ -3,7 +3,7 @@ layout: page
 sidenav: true
 type: acquisition
 title: 'Accessibility In Procurement II: Solicitation & Post-Solicitation'
-permalink: buy/accessibility-in-procurement-pre-solicitation-2/
+permalink: buy/accessibility-in-procurement-solicitation-post-2/
 description: Accessibility in Procurement guide developed by TTS to ensure accessibility considerations are taken into account when purchasing ICT; including solicitation and post-solicitation activities. 
 contributors: proctor, gsatts
 audience:
@@ -17,6 +17,8 @@ resource-type: "Process & How-To"
 format: "HTML"
 created: 2023-09-25 
 updated: 2026-03-31
+redirect_from:
+- buy/accessibility-in-procurement-pre-solicitation-2/
 ---
 
 ## Requests for Quotes (RFQs)/Request for Proposals (RFPs) - “Solicitations”

--- a/_pages/acquisition/2026-03-31-buy-integrate-section-508-in-qasps.md
+++ b/_pages/acquisition/2026-03-31-buy-integrate-section-508-in-qasps.md
@@ -275,7 +275,7 @@ At minimum, include Section 508 requirements in the following sections of a QASP
 <h2>Related Resources</h2>
 <ul>
 <li><a href="https://www.acquisition.gov/far/37.604" target="_blank" class="usa-link--external">37.604 Quality assurance surveillance plans</a> Federal Acquisition Regulation (FAR)</li>  
-<li><a href="{{ site.baseurl }}/buy/accessibility-in-procurement-pre-solicitation-2/">Accessibility In Procurement II: Solicitation and Post-Solicitation</a></li>    
+<li><a href="{{ site.baseurl }}/buy/accessibility-in-procurement-solicitation-post-2/">Accessibility In Procurement II: Solicitation and Post-Solicitation</a></li>    
 <li><a href="{{ site.baseurl }}/buy/">Buy Accessible Products and Services</a></li>     
 <li><a href="{{ site.baseurl }}/manage/governance/ict-accessibility-and-risk-management/">ICT Accessibility and Risk Management</a></li>    
 <li><a href="{{site.baseurl}}/manage/playbooks/technology-accessibility-playbook/8/">Technology Accessibility Playbook - Play 8: Integrate Accessibility Needs into Market Research and Acquisition Processes</a></li>    

--- a/_pages/manage/playbooks/2018-05-15-manage-play-10.md
+++ b/_pages/manage/playbooks/2018-05-15-manage-play-10.md
@@ -353,7 +353,7 @@ This section outlines Key Performance Indicators (KPIs) to track and measure acc
   <div class="itad-card__body">
     <h3>Related Resources and Guidance</h3>
     <ul>
-      <li><a href="{{site.baseurl}}/buy/accessibility-in-procurement-pre-solicitation-2/">Accessibility In Procurement II: Solicitation &amp; Post-Solicitation</a></li>
+      <li><a href="{{site.baseurl}}/buy/accessibility-in-procurement-solicitation-post-2/">Accessibility In Procurement II: Solicitation &amp; Post-Solicitation</a></li>
       <li><a href="{{site.baseurl}}/manage/accessibility-kpi/">Organizational IT Accessibility Key Performance Indicators</a></li>
       <li><a href="https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/text-of-the-standards-and-guidelines" target="_blank" class="usa-link--external">Section 508 Standards</a></li>
       <li><a href="{{site.baseurl}}/buy/understand-claims/">Understanding Vendor Claims in Accessibility Conformance Reports for Section 508 Conformance</a></li>


### PR DESCRIPTION
Closes #1301

Updates Part 2 of the Procurement Guide URL that uses "pre-solicitation" in the URL, to use "solicitation-post" since part 2 addresses accessibility during solicitation and post-solicitation.