### PR TITLE
Fix syntax issue in whats new page and Jekyll/Liquid 4.4.1 

### DIFF
--- a/_pages/misc-pages/2025-07-01-whats-new.md
+++ b/_pages/misc-pages/2025-07-01-whats-new.md
@@ -12,7 +12,7 @@ topic:
 sub-topic:
 - What's New?
 created: 2025-07-01
-updated: 2026-04-20 #date of last edit, not listing of what's new
+updated: 2026-05-17 #date of last edit, not listing of what's new
 hide-date: true #generated automatically in each build via liquid script below
 exclude-changelog: true
 ---
@@ -104,7 +104,12 @@ Step 2: If fewer than 5, pad with fallback (older items)
   {%- comment -%}
   Remove anything already in primary_items from fallback
   {%- endcomment -%}
-  {% assign fallback_unique = sorted_fallback | where_exp: "item", "primary_items contains item == false" %}
+  {% assign fallback_unique = "" | split: "" %}
+  {% for item in sorted_fallback %}
+    {% unless primary_items contains item %}
+      {% assign fallback_unique = fallback_unique | push: item %}
+    {% endunless %}
+  {% endfor %}
 
   {% assign fallback_slice = fallback_unique | slice: 0, needed %}
 


### PR DESCRIPTION
This fixes an issue that cropped up between thursday and sunday and fixes an issue in "whats new" page where Jekyll/Liquid 4.4.1 doesn’t like that comparison after contains around line 106, so it fails parsing before the page can build. I replaced it with a plain Liquid loop using {% unless primary_items contains item %}.