### PR TITLE
Fix CodeQL JavaScript parse error and exclude .js files with Liquid code for Jekyll

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+name: Section508 CodeQL configuration
+
+# These source files require Jekyll front matter and Liquid processing before
+# they are valid JavaScript. Exclude only these templates from source analysis.
+paths-ignore:
+  - assets/js/content-library.js
+  - assets/js/external-508-blocks.js

--- a/assets/online-training/micro-purchases-and-section-508-requirements/lib/rise/10cbab57.js
+++ b/assets/online-training/micro-purchases-and-section-508-requirements/lib/rise/10cbab57.js
@@ -35515,7 +35515,7 @@
                     }
                 }, t.pattern = {
                     // Match a style rule with minimized ambiguity
-                    style: /([-a-z]+)[\s\n]*:[\s\n]*((?:'[^']*'|"[^"]*")?)[\s\n]*(?:;|$)/g
+                    style: /([-a-z]+)[\s\n]*:[\s\n]*((?:'[^']*'|"[^"]*")?)[\s\n]*(?:;|$)/g,
                     // Use a more predictable dotAll pattern for comments
                     comment: /\/\*[\s\S]*?\*\//g
                 }, t.connect = {


### PR DESCRIPTION
- Fixes missing comma in Rise-generated online course .js file.
- Adds CodeQL config file to exclude two .js files with Liquid code necessary for Jekyll build