### PR TITLE
Update Angular framework; replace legacy Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,8 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "ruby:bundler"
-    directory: "/"
-    update_schedule: "weekly"
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      angular-security:
+        applies-to: security-updates
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+      angular-version:
+        applies-to: version-updates
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"

--- a/angular-build.sh
+++ b/angular-build.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
-# angular build script for ART
-#npm link @angular/cli;
-echo "Starting Angular Build";
-#Initializing he base url, which is the federalist demo link url without the brnach name at the end
-baseurl='https://federalist-7a132a2e-6307-4cd0-9f82-e30e871d214a.sites.pages.cloud.gov/preview/gsa/section508.gov/'; 
-# The actual url needed for will be the base url with the branch in which the code will be pushed. Since art code will be run in the art directory, we all append that directory
-url=$baseurl${BRANCH}"/art/";
-echo 'Base href -> ' $url; 
-#if the code is push on the main branch
-[ ${BRANCH} = 'main' ] && ng build --configuration production --base-href=https://www.section508.gov/art/;  
-#if the code is pushed on any pther brnach, they will be using federalist cloud from url
-[ ${BRANCH} != 'main' ] && ng build --configuration dev --base-href=$url;
-echo 'Angular build completed!'; 
+set -euo pipefail
+
+# Cloud.gov Pages supplies the branch used for the ART preview URL.
+: "${BRANCH:?BRANCH must be set for the Cloud.gov Pages Angular build}"
+
+echo "Starting Angular Build"
+if [[ "$BRANCH" == "main" ]]; then
+  configuration=production
+  url='https://www.section508.gov/art/'
+else
+  configuration=dev
+  baseurl='https://federalist-7a132a2e-6307-4cd0-9f82-e30e871d214a.sites.pages.cloud.gov/preview/gsa/section508.gov/'
+  url="${baseurl}${BRANCH}/art/"
+fi
+
+echo "Base href -> $url"
+ng build --configuration "$configuration" --base-href="$url"
+echo "Angular build completed!"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
       "name": "federalist-uswds-jekyll",
       "version": "1.3.0",
       "dependencies": {
-        "@angular/common": "^20.3.27",
-        "@angular/compiler": "^20.3.27",
-        "@angular/core": "^20.3.27",
-        "@angular/forms": "^20.3.27",
-        "@angular/platform-browser": "^20.3.27",
-        "@angular/router": "^20.3.27",
+        "@angular/common": "^20.3.28",
+        "@angular/compiler": "^20.3.28",
+        "@angular/core": "^20.3.28",
+        "@angular/forms": "^20.3.28",
+        "@angular/platform-browser": "^20.3.28",
+        "@angular/router": "^20.3.28",
         "@fortawesome/fontawesome-free": "~6.2.0",
         "@uswds/uswds": "3.7.1",
         "clipboard-copy": "^4.0.1",
@@ -29,7 +29,7 @@
       "devDependencies": {
         "@angular-devkit/build-angular": "^20.3.32",
         "@angular/cli": "~20.3.32",
-        "@angular/compiler-cli": "^20.3.27",
+        "@angular/compiler-cli": "^20.3.28",
         "@types/jasmine": "~4.0.0",
         "jasmine-core": "~4.3.0",
         "js-yaml": "^4.3.2",
@@ -535,24 +535,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@angular/animations": {
-      "version": "20.3.27",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.27.tgz",
-      "integrity": "sha512-BgGTloDiD3qIFVSxZq8xO6CiyhKn00WbhQQiklZF8WI2hXd3Hmc1OUAAHqSMh2c9uL7X1ZYkg9lSzjiasK2vKg==",
-      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "20.3.27"
-      }
-    },
     "node_modules/@angular/build": {
       "version": "20.3.32",
       "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.32.tgz",
@@ -688,9 +670,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "20.3.27",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.27.tgz",
-      "integrity": "sha512-4ectYP60XatB9zZ40WlfmaTzjmEhaz8SSqLsbZI4VZ8gDb5qNmxWtwwt8UxS3NmDHEgqdNL8UPO4E94+yKCICg==",
+      "version": "20.3.28",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.28.tgz",
+      "integrity": "sha512-vvMrBI0POHYeUE8EnN4ohYOqLkmZXI6oKJnMvarfukySnw7mZ4VuY4DNAnRSbEZEqO55sOmVCQ7jbxDDt34tZw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -699,14 +681,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "20.3.27",
+        "@angular/core": "20.3.28",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "20.3.27",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.27.tgz",
-      "integrity": "sha512-in3THZ678GAYuOR9RZV18+zZz0KGhlGikyUEfLeALLjGf9ZaR3n+t19BmYx6G2VkF/Xqadne1omQ2vbl6PRASA==",
+      "version": "20.3.28",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.28.tgz",
+      "integrity": "sha512-3iSkIWJEVrdG4Zv0vQs0ieO185aJfb5Vn3whi/D7QEDUNEsHGZSxRDxT1hyDGIaj52FN6+Qo5SFSSsDf+vgUAA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -716,9 +698,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "20.3.27",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.27.tgz",
-      "integrity": "sha512-R0j9mFfUdGmmw867V/TfMSOBkLZT6ASxyY5tc1NDNmxQioZDVIDP9pqBOayzhJ0xiuDc9JellQXUTZ+vm+b/Zg==",
+      "version": "20.3.28",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.28.tgz",
+      "integrity": "sha512-HZH4HH02mMOlZuXOXnnnHWK39bsPjbKRK6XJhLTu7T/0/iUFOiH0NTkkWrpjKXwn5eSDYhmJGCmWcJyW/LUaLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -739,7 +721,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.3.27",
+        "@angular/compiler": "20.3.28",
         "typescript": ">=5.8 <6.0"
       },
       "peerDependenciesMeta": {
@@ -749,9 +731,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "20.3.27",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.27.tgz",
-      "integrity": "sha512-8EfYIUST5CKldOF4MAYWTFFRB7EtwqUoQBZdar6US39/EEzWm/wm/iRNkH2jmKe4YuPa2GoeHS1WQ8VRuOk7Dg==",
+      "version": "20.3.28",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.28.tgz",
+      "integrity": "sha512-R28TMoEr+mBUswemFWZdHAuK2WDSs+6eYFBg6XrBmlMlmG4YkWeNFxRbJNYDkF8RH+fpguS+iUH63yLpts22dA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -760,7 +742,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.3.27",
+        "@angular/compiler": "20.3.28",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0"
       },
@@ -774,9 +756,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "20.3.27",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.27.tgz",
-      "integrity": "sha512-cNG26wi3tr3m8At6puxJpAMVk9mBhEqREA4Jk/klalMwWuYEf8ApTEAw0a5NUfMxDkL3dcJJwDRf8rK6ma6TYQ==",
+      "version": "20.3.28",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.28.tgz",
+      "integrity": "sha512-at81TpBs/NxvOyR5IhtUClG+2WVMLVDieFRz+rAH+ok9dtRrDHoKPQOgMAEw9q5N4yO4CZKhfAPq+5P/gnnjsw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -785,16 +767,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.27",
-        "@angular/core": "20.3.27",
-        "@angular/platform-browser": "20.3.27",
+        "@angular/common": "20.3.28",
+        "@angular/core": "20.3.28",
+        "@angular/platform-browser": "20.3.28",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "20.3.27",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.27.tgz",
-      "integrity": "sha512-IV2zQ4zk6liyw5NE48bQqSk3nOAZ1rmDAQi7W4Kw0N8cs9MYVgK3zulo0zx5UqSv1kuNDAGb0HPR5tUGVOf9kw==",
+      "version": "20.3.28",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.28.tgz",
+      "integrity": "sha512-TER/xSXlDsqlbM4Eufkjzm7HvB88K6pbudl7Xs6H3huTkg9Lw4zuFIpnk+fpLOGcc7/rpFIb00k/LhzkwuQiIw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -803,9 +785,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "20.3.27",
-        "@angular/common": "20.3.27",
-        "@angular/core": "20.3.27"
+        "@angular/animations": "20.3.28",
+        "@angular/common": "20.3.28",
+        "@angular/core": "20.3.28"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -814,9 +796,9 @@
       }
     },
     "node_modules/@angular/router": {
-      "version": "20.3.27",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.27.tgz",
-      "integrity": "sha512-F3hfJQ0GAuD6LdeB7A6fMfaErc4HXCtCQGh3C/8VrbVEbGfIgSveNjQXzGYPNklnOLhj1BmWf5w0WniUAEjLBA==",
+      "version": "20.3.28",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.28.tgz",
+      "integrity": "sha512-W4sNTrYT2oavpJ/MgUYpnCkhJ0vBS3KXZVRNruURUI/wLirF+AoXvMSlke9SlytrdvPAx8Www+nq0dyY2Ln96Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -825,9 +807,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.27",
-        "@angular/core": "20.3.27",
-        "@angular/platform-browser": "20.3.27",
+        "@angular/common": "20.3.28",
+        "@angular/core": "20.3.28",
+        "@angular/platform-browser": "20.3.28",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "federalist": " bash ./angular-build.sh; "
   },
   "dependencies": {
-    "@angular/common": "^20.3.27",
-    "@angular/compiler": "^20.3.27",
-    "@angular/core": "^20.3.27",
-    "@angular/forms": "^20.3.27",
-    "@angular/platform-browser": "^20.3.27",
-    "@angular/router": "^20.3.27",
+    "@angular/common": "^20.3.28",
+    "@angular/compiler": "^20.3.28",
+    "@angular/core": "^20.3.28",
+    "@angular/forms": "^20.3.28",
+    "@angular/platform-browser": "^20.3.28",
+    "@angular/router": "^20.3.28",
     "@fortawesome/fontawesome-free": "~6.2.0",
     "@uswds/uswds": "3.7.1",
     "clipboard-copy": "^4.0.1",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@angular-devkit/build-angular": "^20.3.32",
     "@angular/cli": "~20.3.32",
-    "@angular/compiler-cli": "^20.3.27",
+    "@angular/compiler-cli": "^20.3.28",
     "@types/jasmine": "~4.0.0",
     "jasmine-core": "~4.3.0",
     "js-yaml": "^4.3.2",


### PR DESCRIPTION
- Updated all seven Angular framework/compiler packages to 20.3.28 and regenerated the lockfile.
- Fixed angular-build.sh to propagate failures and validate BRANCH.
- Replaced legacy Dependabot configuration with Angular security/version grouping.